### PR TITLE
da changes for da mapping

### DIFF
--- a/maps/_common/areas/station/engineering.dm
+++ b/maps/_common/areas/station/engineering.dm
@@ -128,7 +128,3 @@
 	name = "Engineering - Backup Power Storage"
 	icon_state = "substation"
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
-
-/area/engineering/bluespace_drive
-	name = "Engineering - Bluespace Drive"
-	icon_state = "engine"

--- a/maps/sccv_horizon/code/sccv_horizon_areas.dm
+++ b/maps/sccv_horizon/code/sccv_horizon_areas.dm
@@ -49,6 +49,14 @@
 /area/hallway/engineering/rust
 	name = "Engineering - INDRA Hallway"
 
+/area/engineering/bluespace_drive
+	name = "Engineering - Bluespace Drive"
+	icon_state = "engine"
+
+/area/engineering/bluespace_drive/monitoring
+	name = "Engineering - Bluespace Drive"
+	icon_state = "engineering"
+
 //Medical
 
 /area/medical/ors


### PR DESCRIPTION
Here's the map stuff. I moved some things around in the files too, you had the area for the bluespace drive in the wrong file. All that needs to be done map wise is replacing the computer with a terminal. **Do not have Matt update the testmerge with this yet. While the computer is the map right now, it seems like there's a problem with it not playing nice with the camera terminal next to it. This issue causes the computer to be removed from the map, and breaks the camera monitors sprite.**
Also, please note this in the changelog
rscadd: "Edited and partially remapped the deck one starboard engineering maints and the deck two aft auxiliary atmospherics. The auxiliary has been replaced with drone manufacturing."
rcsadd: "Modified the supermatter cooling loop, giving it a slight increase in cooling potential. Please be mindful when doing more experimental setups."
